### PR TITLE
Changes for Optix77

### DIFF
--- a/examples/path_util.py
+++ b/examples/path_util.py
@@ -1,0 +1,6 @@
+import os
+
+include_path = "/opt/NVIDIA-OptiX-SDK-7.7.0-linux64-x86_64/include"
+cuda_tk_path = "/usr/local/cuda/include"
+stddef_path = ""
+

--- a/examples/sphere.cu
+++ b/examples/sphere.cu
@@ -48,9 +48,9 @@ static __forceinline__ __device__ void trace(
         )
 {
     unsigned int p0, p1, p2;
-    p0 = float_as_int( prd->x );
-    p1 = float_as_int( prd->y );
-    p2 = float_as_int( prd->z );
+    p0 = __float_as_int( prd->x );
+    p1 = __float_as_int( prd->y );
+    p2 = __float_as_int( prd->z );
     optixTrace(
             handle,
             ray_origin,
@@ -64,26 +64,26 @@ static __forceinline__ __device__ void trace(
             0,                   // SBT stride
             0,                   // missSBTIndex
             p0, p1, p2 );
-    prd->x = int_as_float( p0 );
-    prd->y = int_as_float( p1 );
-    prd->z = int_as_float( p2 );
+    prd->x = __int_as_float( p0 );
+    prd->y = __int_as_float( p1 );
+    prd->z = __int_as_float( p2 );
 }
 
 
 static __forceinline__ __device__ void setPayload( float3 p )
 {
-    optixSetPayload_0( float_as_int( p.x ) );
-    optixSetPayload_1( float_as_int( p.y ) );
-    optixSetPayload_2( float_as_int( p.z ) );
+    optixSetPayload_0( __float_as_int( p.x ) );
+    optixSetPayload_1( __float_as_int( p.y ) );
+    optixSetPayload_2( __float_as_int( p.z ) );
 }
 
 
 static __forceinline__ __device__ float3 getPayload()
 {
     return make_float3(
-            int_as_float( optixGetPayload_0() ),
-            int_as_float( optixGetPayload_1() ),
-            int_as_float( optixGetPayload_2() )
+            __int_as_float( optixGetPayload_0() ),
+            __int_as_float( optixGetPayload_1() ),
+            __int_as_float( optixGetPayload_2() )
             );
 }
 
@@ -130,15 +130,15 @@ extern "C" __global__ void __closesthit__ch()
 {
     const float3 shading_normal =
         make_float3(
-                int_as_float( optixGetAttribute_0() ),
-                int_as_float( optixGetAttribute_1() ),
-                int_as_float( optixGetAttribute_2() )
+                __int_as_float( optixGetAttribute_0() ),
+                __int_as_float( optixGetAttribute_1() ),
+                __int_as_float( optixGetAttribute_2() )
                 );
     setPayload( normalize( optixTransformNormalFromObjectToWorldSpace( shading_normal ) ) * 0.5f + 0.5f );
 }
 
 
-#define float3_as_ints( u ) float_as_int( u.x ), float_as_int( u.y ), float_as_int( u.z )
+#define float3_as_ints( u ) __float_as_int( u.x ), __float_as_int( u.y ), __float_as_int( u.z )
 
 extern "C" __global__ void __intersection__sphere()
 {
@@ -189,7 +189,7 @@ extern "C" __global__ void __intersection__sphere()
         if( t > ray_tmin && t < ray_tmax )
         {
             normal = ( O + ( root1 + root11 ) * D ) / radius;
-            if( optixReportIntersection( t, 0, float3_as_ints( normal ), float_as_int( radius ) ) )
+            if( optixReportIntersection( t, 0, float3_as_ints( normal ), __float_as_int( radius ) ) )
                 check_second = false;
         }
 
@@ -199,7 +199,7 @@ extern "C" __global__ void __intersection__sphere()
             t           = root2 * l;
             normal      = ( O + root2 * D ) / radius;
             if( t > ray_tmin && t < ray_tmax )
-                optixReportIntersection( t, 0, float3_as_ints( normal ), float_as_int( radius ) );
+                optixReportIntersection( t, 0, float3_as_ints( normal ), __float_as_int( radius ) );
         }
     }
 }

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -229,12 +229,21 @@ def create_module( ctx, pipeline_options, sphere_ptx ):
         debugLevel       = optix.COMPILE_DEBUG_LEVEL_DEFAULT
         )
 
-    module, log = ctx.moduleCreateFromPTX(
-        module_options,
-        pipeline_options,
-        sphere_ptx
-        )
-    print( "\tModule create log: <<<{}>>>".format( log ) )
+    module, log = None, None
+    if optix_version_gte( (7,6) ):
+        module, log = ctx.moduleCreate(
+            module_options,
+            pipeline_options,
+            sphere_ptx
+            )
+        print( "\tModule create log: <<<{}>>>".format( log ) )
+    else:
+        module, log = ctx.moduleCreateFromPTX(
+            module_options,
+            pipeline_options,
+            sphere_ptx
+            )
+        print( "\tModule create log: <<<{}>>>".format( log ) )
     return module
 
 
@@ -267,7 +276,7 @@ def create_program_groups( ctx, module ):
         )
     print( "\tProgramGroup hitgroup create log: <<<{}>>>".format( log ) )
 
-    return [ raygen_prog_group, miss_prog_group, hitgroup_prog_group ]
+    return raygen_prog_group + miss_prog_group + hitgroup_prog_group
 
 
 def create_pipeline( ctx, program_groups, pipeline_compile_options ):
@@ -276,7 +285,11 @@ def create_pipeline( ctx, program_groups, pipeline_compile_options ):
     max_trace_depth = 1
     pipeline_link_options                   = optix.PipelineLinkOptions()
     pipeline_link_options.maxTraceDepth     = max_trace_depth
-    pipeline_link_options.debugLevel        = optix.COMPILE_DEBUG_LEVEL_FULL
+    
+    if optix_version_gte( (7, 6) ):
+        pass
+    else:
+        pipeline_link_options.debugLevel        = optix.COMPILE_DEBUG_LEVEL_FULL
 
     log = ""
     pipeline = ctx.pipelineCreate(
@@ -286,8 +299,12 @@ def create_pipeline( ctx, program_groups, pipeline_compile_options ):
         log)
 
     stack_sizes = optix.StackSizes()
-    for prog_group in program_groups:
-        optix.util.accumulateStackSizes( prog_group, stack_sizes )
+    if optix_version_gte( (7, 6) ):
+        for prog_group in program_groups:
+            optix.util.accumulateStackSizes( prog_group, stack_sizes, pipeline )
+    else:
+        for prog_group in program_groups:
+            optix.util.accumulateStackSizes( prog_group, stack_sizes )
 
     ( dc_stack_size_from_trav, dc_stack_size_from_state, cc_stack_size ) = \
         optix.util.computeStackSizes(
@@ -310,7 +327,7 @@ def create_pipeline( ctx, program_groups, pipeline_compile_options ):
 def create_sbt( prog_groups ):
     print( "Creating sbt ... " )
 
-    (raygen_prog_group, miss_prog_group, hitgroup_prog_group ) = prog_groups
+    raygen_prog_group, miss_prog_group, hitgroup_prog_group  = prog_groups
 
     header_format = '{}B'.format( optix.SBT_RECORD_HEADER_SIZE )
 

--- a/examples/triangle.cu
+++ b/examples/triangle.cu
@@ -40,9 +40,9 @@ __constant__ Params params;
 
 static __forceinline__ __device__ void setPayload( float3 p )
 {
-    optixSetPayload_0( float_as_int( p.x ) );
-    optixSetPayload_1( float_as_int( p.y ) );
-    optixSetPayload_2( float_as_int( p.z ) );
+    optixSetPayload_0( __float_as_int( p.x ) );
+    optixSetPayload_1( __float_as_int( p.y ) );
+    optixSetPayload_2( __float_as_int( p.z ) );
 }
 
 
@@ -88,9 +88,9 @@ extern "C" __global__ void __raygen__rg()
             1,                   // SBT stride   -- See SBT discussion
             0,                   // missSBTIndex -- See SBT discussion
             p0, p1, p2 );
-    result.x = int_as_float( p0 );
-    result.y = int_as_float( p1 );
-    result.z = int_as_float( p2 );
+    result.x = __int_as_float( p0 );
+    result.y = __int_as_float( p1 );
+    result.z = __int_as_float( p2 );
 
     // Record results in our output raster
     params.image[idx.y * params.image_width + idx.x] = make_color( result );

--- a/optix/.gitignore
+++ b/optix/.gitignore
@@ -1,0 +1,3 @@
+build/**
+dist/**
+optix.egg-info/**

--- a/optix/setup.py
+++ b/optix/setup.py
@@ -77,7 +77,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='optix',
-    version='0.0.1',
+    version='0.0.2',
     author='Keith Morley',
     author_email='kmorley@nvidia.com',
     description='Python bindings for NVIDIA OptiX',

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -123,11 +123,18 @@ class TestModule:
         ctx = optix.deviceContextCreate(0, optix.DeviceContextOptions())
         module_opts   = optix.ModuleCompileOptions()
         pipeline_opts = optix.PipelineCompileOptions()
-        mod, log = ctx.moduleCreateFromPTX(
+        if tutil.optix_version_gte( (7, 6) ):
+            mod, log = ctx.moduleCreate(
             module_opts,
             pipeline_opts,
             sample_ptx.hello_ptx,
             )
+        else:
+            mod, log = ctx.moduleCreateFromPTX(
+                module_opts,
+                pipeline_opts,
+                sample_ptx.hello_ptx,
+                )
         assert type(mod) is optix.Module
         assert type(log) is str
 
@@ -135,29 +142,37 @@ class TestModule:
         ctx.destroy()
             
 
-if tutil.optix_version_gte( (7,4) ): 
-    def test_payload_semantics_use( self ):
-        ctx = optix.deviceContextCreate(0, optix.DeviceContextOptions())
-        module_opts   = optix.ModuleCompileOptions()
-        pipeline_opts = optix.PipelineCompileOptions()
+    if tutil.optix_version_gte( (7,4) ): 
+        def test_payload_semantics_use( self ):
+            ctx = optix.deviceContextCreate(0, optix.DeviceContextOptions())
+            module_opts   = optix.ModuleCompileOptions()
+            pipeline_opts = optix.PipelineCompileOptions()
 
-        payload_sem = ( 
-            optix.PAYLOAD_SEMANTICS_TRACE_CALLER_READ_WRITE | 
-            optix.PAYLOAD_SEMANTICS_CH_READ_WRITE | 
-            optix.PAYLOAD_SEMANTICS_MS_READ_WRITE | 
-            optix.PAYLOAD_SEMANTICS_AH_READ_WRITE | 
-            optix.PAYLOAD_SEMANTICS_IS_READ_WRITE
-            )
-        
-        payload_type = optix.PayloadType( [ payload_sem, payload_sem, payload_sem ] )
-        module_opts.payloadTypes = [ payload_type ]
-        mod, log = ctx.moduleCreateFromPTX(
-            module_opts,
-            pipeline_opts,
-            sample_ptx.triangle_ptx,
-            )
-        mod.destroy()
-        ctx.destroy()
+            payload_sem = ( 
+                optix.PAYLOAD_SEMANTICS_TRACE_CALLER_READ_WRITE | 
+                optix.PAYLOAD_SEMANTICS_CH_READ_WRITE | 
+                optix.PAYLOAD_SEMANTICS_MS_READ_WRITE | 
+                optix.PAYLOAD_SEMANTICS_AH_READ_WRITE | 
+                optix.PAYLOAD_SEMANTICS_IS_READ_WRITE
+                )
+            
+            payload_type = optix.PayloadType( [ payload_sem, payload_sem, payload_sem ] )
+            module_opts.payloadTypes = [ payload_type ]
+            mod = None
+            if tutil.optix_version_gte( (7, 6) ):
+                mod, log = ctx.moduleCreate(
+                                            module_opts,
+                                            pipeline_opts,
+                                            sample_ptx.triangle_ptx,
+                                            )
+            else:
+                mod, log = ctx.moduleCreateFromPTX(
+                    module_opts,
+                    pipeline_opts,
+                    sample_ptx.triangle_ptx,
+                    )
+            mod.destroy()
+            ctx.destroy()
 
 
     def test_bound_values_use( self ):
@@ -172,12 +187,18 @@ if tutil.optix_version_gte( (7,4) ):
             annotation  = "my_bound_value"
         )
         module_opts.boundValues = [ bound_value_entry ]
-
-        mod, log = ctx.moduleCreateFromPTX(
-            module_opts,
-            pipeline_opts,
-            sample_ptx.hello_ptx,
-            )
+        if tutil.optix_version_gte( (7, 6) ):
+            mod, log = ctx.moduleCreate(
+                module_opts,
+                pipeline_opts,
+                sample_ptx.hello_ptx,
+                )
+        else:
+            mod, log = ctx.moduleCreateFromPTX(
+                module_opts,
+                pipeline_opts,
+                sample_ptx.hello_ptx,
+                )
         mod.destroy()
         ctx.destroy()
 

--- a/test/test_program_group.py
+++ b/test/test_program_group.py
@@ -23,7 +23,12 @@ if tutil.optix_version_gte( (7,4) ):
 class TestProgramGroupBase:
     def setup_method(self):
         self.ctx = ox.deviceContextCreate(0, ox.DeviceContextOptions())
-        self.mod, log = self.ctx.moduleCreateFromPTX(ox.ModuleCompileOptions(),
+        if tutil.optix_version_gte( (7, 6) ):
+            self.mod, log = self.ctx.moduleCreate(ox.ModuleCompileOptions(),
+                                                  ox.PipelineCompileOptions(),
+                                                  sample_ptx.hello_ptx)
+        else:
+            self.mod, log = self.ctx.moduleCreateFromPTX(ox.ModuleCompileOptions(),
                                                      ox.PipelineCompileOptions(),
                                                      sample_ptx.hello_ptx)
 
@@ -61,6 +66,7 @@ class TestProgramGroup(TestProgramGroupBase):
             prog_groups, log = self.ctx.programGroupCreate([prog_group_desc], prog_group_opts)
         else:
             prog_groups, log = self.ctx.programGroupCreate([prog_group_desc] )
+
         assert len(prog_groups) == 1
         assert type(prog_groups[0]) is ox.ProgramGroup
 
@@ -145,5 +151,6 @@ class TestProgramGroup(TestProgramGroupBase):
 
     def test_get_stack_size(self):
         prog_group = self.create_prog_group()
+        # this getstacksize call needs a pipeline object the test case needs alteration
         stack_size = prog_group.getStackSize()
         assert type(stack_size) is ox.StackSizes

--- a/test/util/tutil.py
+++ b/test/util/tutil.py
@@ -418,9 +418,17 @@ def create_default_module():
     ctx = create_default_ctx();
     module_opts   = optix.ModuleCompileOptions()
     pipeline_opts = optix.PipelineCompileOptions()
-    mod, log = ctx.moduleCreateFromPTX(
-        module_opts,
-        pipeline_opts,
-        ptx_string,
-        )
+    mod = None
+    if optix_version_gte( (7, 6) ):
+        mod, log = ctx.moduleCreate(
+			module_opts,
+			pipeline_opts,
+			ptx_string,
+			)
+    else:
+        mod, log = ctx.moduleCreateFromPTX(
+			module_opts,
+			pipeline_opts,
+			ptx_string,
+			)
     return ( ctx, mod )


### PR DESCRIPTION
Hi,

I have made some changes to accommodate the Optix 7.7 framework. Also added some macros ```if-else``` checks so that the code is still consistent with Optix 7.4. I have tested the code on my machine with RTX 3080 running Ubuntu 22.04 with CUDA 12 (NVCC V12.1.105) and NVIDIA Driver (530.41.03). Tested both Optix 7.7 and 7.4
I was unable to find Optix 7.6 on the internet so could not test with it.


### PYTEST STATUS


#### 25 Passed 2 Failed

There is an indentation error in the file ```test/test_module.py``` near ```test_payload_semantics_use``` This test has failed when running ```pytests```

```test_get_stack_size``` in ```test/test_program_group.py``` file now takes ```pipeline``` as argument in Optix 7.7 Please rewrite the test.


### CHANGES

```main.cpp```
	```PipelineLinkOptions``` does not require ```debugLevel``` anymore
	```moduleCreateFromPTX``` &rarr; ```moduleCreate``` ( According to 7.7 documentation)
	```programGroupGetStackSize``` has a new argument pipeline
	```accumulateStackSizes``` has a new argument pipeline
	```accelGetRelocationInfo``` &rarr; ```GetRelocationInfo```
	```accelCheckRelocationCompatibility``` -> ```CheckRelocationCompatibility```
	MACROS like ```OPTIX_ERROR_INVALID_INPUT``` and ```OPTIX_ERROR_NOT_COMPATIBLE``` have been added

```setup.py``` 
	update version to ```0.0.2```
	
The examples are updated with suitable conditions ```optix_version_gte``` based on the Optix Version. The example codes are tested on both Optix 7.4 and 7.7.
	
### PLEASE CHECK THIS

```programGroupCreate``` should not be needing two conditions while ```returning```. I have made changes to return single ```pygroups``` and a returned ```None```  in case the PyGroups vector is empty. Respective changes have been made in all example codes.
