### PR TITLE
Fix nested list in create_program_groups

### DIFF
--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -252,7 +252,7 @@ def create_program_groups( ctx, module ):
         )
     print( "\tProgramGroup hitgroup create log: <<<{}>>>".format( log ) )
 
-    return [ raygen_prog_group, miss_prog_group, hitgroup_prog_group ]
+    return [ raygen_prog_group[0], miss_prog_group[0], hitgroup_prog_group[0] ]
 
 
 def create_pipeline( ctx, program_groups, pipeline_compile_options ):


### PR DESCRIPTION
### Version
I tested both `NVIDIA-OptiX-SDK-7.3.0` and `NVIDIA-OptiX-SDK-7.4.0`.

### Error

```python
Traceback (most recent call last):
  File "/.../otk-pyoptix/examples/triangle.py", line 453, in <module>
    main()
  File "/.../otk-pyoptix/examples/triangle.py", line 440, in main
    pipeline         = create_pipeline( ctx, prog_groups, pipeline_options )
  File "/.../otk-pyoptix/examples/triangle.py", line 267, in create_pipeline
    pipeline = ctx.pipelineCreate(
RuntimeError: Unable to cast Python instance of type <class 'list'> to C++ type 'pyoptix::ProgramGroup'
```

As the same issue occurs for `examples/triangles.py` and other examples. It might be related to version compatibility.

### Reason

`pipelineCreate` expects a list of `ProgramGroup`s. However, `create_program_groups` returns a nested list of program groups. See the following debugging log:

```python
> /.../otk-pyoptix/examples/triangle.py(268)create_pipeline()
    258 def create_pipeline( ctx, program_groups, pipeline_compile_options ):
    259     print( "Creating pipeline ... " )
    260 
    261     max_trace_depth  = 1
    262     pipeline_link_options               = optix.PipelineLinkOptions()
    263     pipeline_link_options.maxTraceDepth = max_trace_depth
    264     pipeline_link_options.debugLevel    = optix.COMPILE_DEBUG_LEVEL_FULL
    265 
    266     log = ""
    267     import ipdb; ipdb.set_trace(context=20)
--> 268     pipeline = ctx.pipelineCreate(
    269             pipeline_compile_options,
    270             pipeline_link_options,
    271             program_groups,
    272             log)
    273 
    274     stack_sizes = optix.StackSizes()
    275     for prog_group in program_groups:
    276         optix.util.accumulateStackSizes( prog_group, stack_sizes )
    277 

ipdb> print(program_groups)
[[<optix.ProgramGroup object at 0x7f83765088f0>], [<optix.ProgramGroup object at 0x7f83765089f0>], [<optix.ProgramGroup object at 0x7f8376508a70>]]

```

### Fix
Get the 0-th elements of the `program_groups` list. 
