### PR TITLE
Cmake 4.x updates & fixes for Windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,27 +54,46 @@ pip install pynvrtc
 ```
 
 ### Building and installing the `optix` Python module
-Point `setuptools/CMake` to Optix by setting the following environment variable.
+Point `setuptools/CMake` to OptiX by setting the `OPTIX_INSTALL_DIR` environment variable.
 
 Linux:
-```
-export PYOPTIX_CMAKE_ARGS="-DOptiX_INSTALL_DIR=<optix install dir>"
-```
-Windows:
-```
-set PYOPTIX_CMAKE_ARGS=-DOptiX_INSTALL_DIR=C:\ProgramData\NVIDIA Corporation\OptiX SDK 7.0.0
-```
-
-Build and install using `pip` and `setuptools.py`:
-```
+```bash
+export OPTIX_INSTALL_DIR=/path/to/OptiX-SDK
 cd optix
 pip install .
 ```
 
-When compiling against an Optix 7.0 SDK an additional environment variable needs to be set
+Windows (PowerShell):
+```powershell
+$env:OPTIX_INSTALL_DIR = 'C:\ProgramData\NVIDIA Corporation\OptiX SDK 9.0.0'
+cd optix
+pip install .
+```
+
+Windows (cmd):
+```cmd
+set OPTIX_INSTALL_DIR=C:\ProgramData\NVIDIA Corporation\OptiX SDK 9.0.0
+cd optix
+pip install .
+```
+
+**Note:** Paths with spaces are handled correctly.
+
+For advanced use cases, additional CMake arguments can be passed via `PYOPTIX_CMAKE_ARGS`.
+
+When compiling against an OptiX 7.0 SDK an additional environment variable needs to be set
 containing a path to the system's stddef.h location. E.g.
 ```
 export PYOPTIX_STDDEF_DIR="/usr/include/linux"
+```
+
+### Windows: CUDA DLL Loading (Python 3.8+)
+
+Python 3.8+ on Windows no longer uses `PATH` to find DLLs. PyOptiX will auto-detect
+CUDA from the `CUDA_PATH` environment variable. If auto-detection fails, set `CUDA_BIN_DIR`:
+
+```powershell
+$env:CUDA_BIN_DIR = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9\bin'
 ```
 
 ## Running the Examples

--- a/optix/CMake/FindOptiX.cmake
+++ b/optix/CMake/FindOptiX.cmake
@@ -38,7 +38,7 @@ endmacro()
 
 # Locate the OptiX distribution.  Search relative to the SDK first, then look in the system.
 
-find_path(OptiX_ROOT_DIR NAMES include/optix.h PATHS ${OptiX_INSTALL_DIR})
+find_path(OptiX_ROOT_DIR NAMES include/optix.h PATHS "${OptiX_INSTALL_DIR}")
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(OptiX

--- a/optix/CMakeLists.txt
+++ b/optix/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.17...3.31)
 project(optix)
 
 #------------------------------------------------------------------------------
@@ -14,14 +14,10 @@ message(VERBOSE "Finding pybind11...")
 FetchContent_Declare(
     pybind11
     GIT_REPOSITORY https://github.com/pybind/pybind11
-    GIT_TAG        v2.9.2
+    GIT_TAG        v2.13.6
     GIT_SHALLOW    TRUE
     )
-FetchContent_GetProperties(pybind11)
-if(NOT pybind11_POPULATED)
-    FetchContent_Populate(pybind11)
-    add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
-endif()
+FetchContent_MakeAvailable(pybind11)
 
 #------------------------------------------------------------------------------
 # set environment
@@ -43,20 +39,20 @@ configure_file("${CMAKE_SOURCE_DIR}/path_util.py.in" "${CMAKE_SOURCE_DIR}/../exa
 # main build
 #------------------------------------------------------------------------------
 
-pybind11_add_module(optix main.cpp)
+pybind11_add_module(_optix main.cpp)
 
-target_link_libraries( optix PRIVATE
+target_link_libraries( _optix PRIVATE
     OptiX::OptiX
     CUDA::cuda_driver
     CUDA::cudart
     )
-target_compile_features( optix PRIVATE
+target_compile_features( _optix PRIVATE
     cxx_std_17
     )
 add_custom_command(
-    TARGET optix POST_BUILD
+    TARGET _optix POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${OptiX_INCLUDE_DIR}
-    $<TARGET_FILE_DIR:optix>/include
+    "${OptiX_INCLUDE_DIR}"
+    $<TARGET_FILE_DIR:_optix>/include
     )
 

--- a/optix/main.cpp
+++ b/optix/main.cpp
@@ -2315,7 +2315,7 @@ py::bytes getDeviceRepresentation( py::object obj )
 } // end namespace pyoptix
 
 
-PYBIND11_MODULE( optix, m )
+PYBIND11_MODULE( _optix, m )
 {
     m.doc() = R"pbdoc(
         OptiX API

--- a/optix/optix_pkg/__init__.py
+++ b/optix/optix_pkg/__init__.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2022 NVIDIA CORPORATION All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+"""
+Python bindings for NVIDIA OptiX.
+
+On Windows with Python 3.8+, this module handles DLL loading for CUDA libraries.
+Set the CUDA_BIN_DIR environment variable to your CUDA bin directory if needed,
+or it will attempt to auto-detect from CUDA_PATH.
+"""
+
+import os
+import sys
+
+def _add_dll_directories():
+    """Add CUDA DLL directories for Windows Python 3.8+."""
+    if sys.platform != 'win32' or not hasattr(os, 'add_dll_directory'):
+        return
+    
+    # Check for explicit CUDA_BIN_DIR first
+    cuda_bin = os.environ.get('CUDA_BIN_DIR')
+    if cuda_bin and os.path.isdir(cuda_bin):
+        os.add_dll_directory(cuda_bin)
+        return
+    
+    # Try to auto-detect from CUDA_PATH
+    cuda_path = os.environ.get('CUDA_PATH')
+    if cuda_path:
+        cuda_bin = os.path.join(cuda_path, 'bin')
+        if os.path.isdir(cuda_bin):
+            os.add_dll_directory(cuda_bin)
+            return
+    
+    # Try common CUDA installation locations
+    for version in ['v12.9', 'v12.8', 'v12.6', 'v12.5', 'v12.4', 'v12.3', 'v12.2', 'v12.1', 'v12.0', 'v11.8']:
+        cuda_bin = rf'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\{version}\bin'
+        if os.path.isdir(cuda_bin):
+            os.add_dll_directory(cuda_bin)
+            return
+
+_add_dll_directories()
+
+# Import everything from the native module
+from ._optix import *
+


### PR DESCRIPTION
Update cmake minimum version for cmake 4+ support
Use FetchContent_MakeAvailable instead of FetchContent_Populate (deprecated in CMake 4.x) Fix path parsing of PYOPTIX_CMAKE_ARGS to allow quoted paths with spaces Update install procedure to use Optix_INSTALL_DIR instead of PYOPTIX_CMAKE_ARGS Bumped pybind11 to v2.13.6
Add DLL load path %CUDA_PATH%/bin on Windows (or fallback to %CUDA_BIN_DIR%)
   (Python 3.8 removed %PATH% from DLL load locations)