### PR TITLE
Small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+examples/my.png
+examples/path_util.py
+optix/build/
+optix/optix.egg-info/

--- a/README.md
+++ b/README.md
@@ -50,30 +50,28 @@ conda activate pyoptix
 ```
 
 ### Building and installing the `optix` Python module
-Point `setuptools/CMake` to OptiX by setting the `OPTIX_INSTALL_DIR` environment variable.
+Point `setuptools/CMake` to OptiX by setting the `OptiX_INSTALL_DIR` environment variable.
 
 Linux:
 ```bash
-export OPTIX_INSTALL_DIR=/path/to/OptiX-SDK
+export OptiX_INSTALL_DIR=/path/to/OptiX-SDK
 cd optix
 pip install .
 ```
 
 Windows (PowerShell):
 ```powershell
-$env:OPTIX_INSTALL_DIR = 'C:\ProgramData\NVIDIA Corporation\OptiX SDK 9.0.0'
+$env:OptiX_INSTALL_DIR = 'C:\ProgramData\NVIDIA Corporation\OptiX SDK 9.0.0'
 cd optix
 pip install .
 ```
 
 Windows (cmd):
 ```cmd
-set OPTIX_INSTALL_DIR=C:\ProgramData\NVIDIA Corporation\OptiX SDK 9.0.0
+set OptiX_INSTALL_DIR=C:\ProgramData\NVIDIA Corporation\OptiX SDK 9.0.0
 cd optix
 pip install .
 ```
-
-**Note:** Paths with spaces are handled correctly.
 
 For advanced use cases, additional CMake arguments can be passed via `PYOPTIX_CMAKE_ARGS`.
 

--- a/optix/setup.py
+++ b/optix/setup.py
@@ -65,8 +65,8 @@ class CMakeBuild(build_ext):
             build_args += ['--', '-j2']
 
         # Dedicated variable for OptiX path - handles spaces without quoting issues
-        if "OPTIX_INSTALL_DIR" in os.environ:
-            cmake_args += ["-DOptiX_INSTALL_DIR=" + os.environ['OPTIX_INSTALL_DIR']]
+        if "OptiX_INSTALL_DIR" in os.environ:
+            cmake_args += ["-DOptiX_INSTALL_DIR=" + os.environ['OptiX_INSTALL_DIR']]
 
         if "PYOPTIX_CMAKE_ARGS" in os.environ:
             cmake_args += shlex.split(os.environ[ 'PYOPTIX_CMAKE_ARGS' ])


### PR DESCRIPTION
Small fixes needed on top of merged cmake4 updates

Add .gitignore for files generated during build & examples execution
Fix capitalization of OptiX_INSTALL_DIR to be consistent & match FindOptiX.cmake